### PR TITLE
[bugfix] selected icon theme

### DIFF
--- a/lib/src/theme/sidebarx_theme.dart
+++ b/lib/src/theme/sidebarx_theme.dart
@@ -42,8 +42,8 @@ class SidebarXTheme {
       margin: margin,
       decoration: decoration ?? BoxDecoration(color: theme.cardColor),
       iconTheme: iconTheme ?? theme.iconTheme,
-      selectedIconTheme:
-          iconTheme ?? theme.iconTheme.copyWith(color: theme.primaryColor),
+      selectedIconTheme: selectedIconTheme ??
+          theme.iconTheme.copyWith(color: theme.primaryColor),
       textStyle: textStyle ?? theme.textTheme.bodyMedium,
       selectedTextStyle: selectedTextStyle ??
           theme.textTheme.bodyMedium?.copyWith(color: theme.primaryColor),


### PR DESCRIPTION
Fix the `mergeFlutterTheme` function that wasn't using the `selectedIconTheme` but the `iconTheme`.

closes https://github.com/Frezyx/sidebarx/issues/2