### PR TITLE
Make margin and padding of SidebarXCell adjustable

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -33,10 +33,6 @@ dependencies:
     path:
       ../
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.4
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.4
 
 dev_dependencies:
   flutter_test:
@@ -46,7 +46,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/src/theme/sidebarx_theme.dart
+++ b/lib/src/theme/sidebarx_theme.dart
@@ -13,6 +13,10 @@ class SidebarXTheme {
     this.selectedTextStyle,
     this.itemDecoration,
     this.selectedItemDecoration,
+    this.itemMargin,
+    this.selectedItemMargin,
+    this.itemPadding,
+    this.selectedItemPadding,
     this.itemTextPadding,
     this.selectedItemTextPadding,
   });
@@ -29,6 +33,10 @@ class SidebarXTheme {
   final TextStyle? selectedTextStyle;
   final BoxDecoration? itemDecoration;
   final BoxDecoration? selectedItemDecoration;
+  final EdgeInsets? itemMargin;
+  final EdgeInsets? selectedItemMargin;
+  final EdgeInsets? itemPadding;
+  final EdgeInsets? selectedItemPadding;
   final EdgeInsets? itemTextPadding;
   final EdgeInsets? selectedItemTextPadding;
 
@@ -49,6 +57,10 @@ class SidebarXTheme {
           theme.textTheme.bodyMedium?.copyWith(color: theme.primaryColor),
       itemDecoration: itemDecoration,
       selectedItemDecoration: selectedItemDecoration,
+      itemMargin: itemMargin,
+      selectedItemMargin: selectedItemMargin,
+      itemPadding: itemPadding,
+      selectedItemPadding: selectedItemPadding,
       itemTextPadding: itemTextPadding,
       selectedItemTextPadding: selectedItemTextPadding,
     );
@@ -71,6 +83,10 @@ class SidebarXTheme {
       selectedIconTheme: selectedIconTheme ?? theme.selectedIconTheme,
       textStyle: textStyle ?? theme.textStyle,
       selectedTextStyle: selectedTextStyle ?? theme.selectedTextStyle,
+      itemMargin: itemMargin ?? theme.itemMargin,
+      selectedItemMargin: selectedItemMargin ?? theme.selectedItemMargin,
+      itemPadding: itemPadding ?? theme.itemPadding,
+      selectedItemPadding: selectedItemPadding ?? theme.selectedItemPadding,
       itemDecoration: itemDecoration ?? theme.itemDecoration,
       selectedItemDecoration:
           selectedItemDecoration ?? theme.selectedItemDecoration,
@@ -89,6 +105,10 @@ class SidebarXTheme {
     TextStyle? selectedTextStyle,
     BoxDecoration? itemDecoration,
     BoxDecoration? selectedItemDecoration,
+    EdgeInsets? itemMargin,
+    EdgeInsets? selectedItemMargin,
+    EdgeInsets? itemPadding,
+    EdgeInsets? selectedItemPadding,
     EdgeInsets? itemTextPadding,
     EdgeInsets? selectedItemTextPadding,
   }) {
@@ -105,6 +125,10 @@ class SidebarXTheme {
       itemDecoration: itemDecoration ?? this.itemDecoration,
       selectedItemDecoration:
           selectedItemDecoration ?? this.selectedItemDecoration,
+      itemMargin: itemMargin ?? this.itemMargin,
+      selectedItemMargin: selectedItemMargin ?? this.selectedItemMargin,
+      itemPadding: itemPadding ?? this.itemPadding,
+      selectedItemPadding: selectedItemPadding ?? this.selectedItemPadding,
       itemTextPadding: itemTextPadding ?? this.itemTextPadding,
       selectedItemTextPadding:
           selectedItemTextPadding ?? this.selectedItemTextPadding,
@@ -113,6 +137,6 @@ class SidebarXTheme {
 
   @override
   String toString() {
-    return 'SidebarXTheme(width: $width, height: $height, padding: $padding, margin: $margin, decoration: $decoration, iconTheme: $iconTheme, selectedIconTheme: $selectedIconTheme, textStyle: $textStyle, selectedTextStyle: $selectedTextStyle, itemDecoration: $itemDecoration, selectedItemDecoration: $selectedItemDecoration, itemTextPadding: $itemTextPadding, selectedItemTextPadding: $selectedItemTextPadding)';
+    return 'SidebarXTheme(width: $width, height: $height, padding: $padding, margin: $margin, decoration: $decoration, iconTheme: $iconTheme, selectedIconTheme: $selectedIconTheme, textStyle: $textStyle, selectedTextStyle: $selectedTextStyle, itemDecoration: $itemDecoration, selectedItemDecoration: $selectedItemDecoration, itemMargin: $itemMargin, selectedItemMargin: $selectedItemMargin, itemPadding: $itemPadding, selectedItemPadding: $selectedItemPadding, itemTextPadding: $itemTextPadding, selectedItemTextPadding: $selectedItemTextPadding)';
   }
 }

--- a/lib/src/widgets/sidebarx_cell.dart
+++ b/lib/src/widgets/sidebarx_cell.dart
@@ -44,6 +44,10 @@ class _SidebarXCellState extends State<SidebarXCell> {
         widget.selected ? theme.selectedTextStyle : theme.textStyle;
     final decoration =
         (widget.selected ? theme.selectedItemDecoration : theme.itemDecoration);
+    final margin =
+        (widget.selected ? theme.selectedItemMargin : theme.itemMargin);
+    final padding =
+        (widget.selected ? theme.selectedItemPadding : theme.itemPadding);
     final textPadding =
         widget.selected ? theme.selectedItemTextPadding : theme.itemTextPadding;
 
@@ -51,8 +55,8 @@ class _SidebarXCellState extends State<SidebarXCell> {
       onTap: widget.onTap,
       child: Container(
         decoration: decoration,
-        padding: const EdgeInsets.all(8),
-        margin: const EdgeInsets.all(4),
+        padding: padding ?? const EdgeInsets.all(8),
+        margin: margin ?? const EdgeInsets.all(4),
         child: Row(
           mainAxisAlignment: widget.extended
               ? MainAxisAlignment.start

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
### Changes
1. The margin and the padding for sidebar items are retrieved from SidebarXTheme. In the parameters of SidebarXTheme these values can be customized. It is possible to adjust these values seperatly for the selected item and the remaining items.
2. The unused dependency on cupertino_icons in the example project has been removed.
3. The dev dependency on flutter_lints has been updated in the package and the example project.