### PR TITLE
#fix: Bug on items position

### DIFF
--- a/lib/src/sidebarx_base.dart
+++ b/lib/src/sidebarx_base.dart
@@ -171,6 +171,7 @@ class _SidebarXState extends State<SidebarX>
       highlightColor: Colors.transparent,
       focusColor: Colors.transparent,
       onTap: () {
+        if (_animationController!.isAnimating) return;
         widget.controller.toggleExtended();
       },
       child: Row(


### PR DESCRIPTION
When a user open and closes the collapsed menu quickly, the position of the items menu becomes wrong


![ezgif com-gif-maker](https://user-images.githubusercontent.com/47899169/190474826-c15faf2d-de19-49cd-a0ac-698ed6d75af8.gif)
