### PR TITLE
Added new option to place footer icons at the bottom or not.

### DIFF
--- a/lib/src/sidebarx_base.dart
+++ b/lib/src/sidebarx_base.dart
@@ -20,6 +20,7 @@ class SidebarX extends StatefulWidget {
     this.animationDuration = const Duration(milliseconds: 300),
     this.collapseIcon = Icons.arrow_back_ios_new,
     this.extendIcon = Icons.arrow_forward_ios,
+    this.reverseFooter = true,
   }) : super(key: key);
 
   /// Default theme of Sidebar
@@ -50,6 +51,9 @@ class SidebarX extends StatefulWidget {
   /// Sidebar showing toggle button if value [true]
   /// not showing if value [false]
   final bool showToggleButton;
+
+  /// Enable footer at the bottom if value [true]
+  final bool reverseFooter;
 
   /// Divider between header and [items]
   final Widget? headerDivider;
@@ -149,7 +153,7 @@ class _SidebarXState extends State<SidebarX>
               if (widget.footerItems.isNotEmpty)
                 Expanded(
                   child: ListView.separated(
-                    reverse: true,
+                    reverse: widget.reverseFooter,
                     itemCount: widget.footerItems.length,
                     separatorBuilder: widget.separatorBuilder ??
                         (_, __) => const SizedBox(height: 8),

--- a/lib/src/widgets/sidebarx_cell.dart
+++ b/lib/src/widgets/sidebarx_cell.dart
@@ -102,9 +102,7 @@ class _SidebarXCellState extends State<SidebarXCell> {
                 widget.item.iconWidget!,
               Flexible(
                 flex: 6,
-                child: FadeTransition(
-                  opacity: _animation,
-                  child: Padding(
+                child: Padding(
                     padding: textPadding ?? EdgeInsets.zero,
                     child: Text(
                       widget.item.label ?? '',
@@ -112,7 +110,6 @@ class _SidebarXCellState extends State<SidebarXCell> {
                       overflow: TextOverflow.fade,
                       maxLines: 1,
                     ),
-                  ),
                 ),
               ),
             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: sidebarx
 description: flutter multiplatform navigation sidebar / side navigationbar / drawer widget
-version: 0.17.1
-homepage: https://github.com/Frezyx/sidebarx
-repository: https://github.com/Frezyx/sidebarx
+version: 0.17.2
+homepage: https://github.com/chordflower/sidebarx
+repository: https://github.com/chordflower/sidebarx
 
 topics:
   - widget


### PR DESCRIPTION
I've noticed that when there is a footer builder enabled to set up a title for a footer, for example, and footer items, the items are aligned to the bottom of the sidebar instead of being immediately below the title.

Looking at the code, I noticed that this is because of the reverse option in the footer list view, to I've added a new property to SidebarX to specify if the list view items should be reversed or not.